### PR TITLE
chore: configure dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
     groups:
       actions-minor:
         update-types:
@@ -14,6 +17,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
     groups:
       npm-development:
         dependency-type: development


### PR DESCRIPTION
## Summary

Configures Dependabot to use [Conventional Commits](https://www.conventionalcommits.org/) format for its commit messages and PR titles.

## Changes

Added `commit-message` configuration to `.github/dependabot.yml`:
- Uses `chore` prefix
- Includes scope (`deps` or `deps-dev`)

## Result

New Dependabot PRs will use format:
- `chore(deps): bump X from Y to Z` (production dependencies)
- `chore(deps-dev): bump X from Y to Z` (development dependencies)

This aligns with the repo's existing commit conventions and works well with Release Please for changelog generation.

## Note

Existing open Dependabot PRs (9 total) can be updated by commenting `@dependabot recreate` on each one after this PR is merged.