### PR TITLE
ci: run CI and dist checks on merge_group events

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Adds `merge_group` triggers to ci.yml and check-dist.yml so required status checks run inside the merge queue. Prereq for enabling the merge queue.